### PR TITLE
add recipes for Mineclonia, MTG

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -5,4 +5,4 @@ author=MatyasP
 version=10205
 
 depends=
-optional_depends=
+optional_depends=xcompat,default,mcl_core

--- a/tools.lua
+++ b/tools.lua
@@ -1,3 +1,20 @@
+has_xcompat = minetest.get_modpath("xcompat") ~= nil
+has_mcl_core = minetest.get_modpath("mcl_core") ~= nil
+has_default = minetest.get_modpath("default") ~= nil
+-- color configuration
+local color_assignment = {
+    a = "blue",
+    b = "red",
+    c = "green",
+    d = "yellow"
+}
+local wool_name
+if has_mcl_core then
+    wool_name = "mcl_wool:"
+else
+    wool_name = "wool:"
+end
+
 -- LOCAL FUNCTIONS
 --
 local function is_colorfacedir_node(pos)
@@ -81,6 +98,35 @@ minetest.register_tool("repainter:repainter_"..rtype, {
         return itemstack
     end,
 })
+if has_xcompat then
+    minetest.register_craft({
+        output = "repainter:repainter_"..rtype,
+        recipe = {
+            { wool_name..color_assignment[rtype] },
+            { xcompat.materials["steel_ingot"] },
+            { xcompat.materials["stick"] }
+        }
+    })
+elseif has_mcl_core then
+    minetest.register_craft({
+        output = "repainter:repainter_"..rtype,
+        recipe = {
+            { "mcl_wool:"..color_assignment[rtype] },
+            { "mcl_core:iron_ingot" },
+            { "group:stick" }
+        }
+    })
+else
+    -- default
+    minetest.register_craft({
+        output = "repainter:repainter_"..rtype,
+        recipe = {
+            { "wool:"..color_assignment[rtype] },
+            { "default:steel_ingot" },
+            { "default:stick" }
+        }
+    })
+end
 end
 
 function repainter_register_rotator(rtype,rrtype,num1,num2,funk)
@@ -112,6 +158,35 @@ minetest.register_tool("repainter:rotator_"..rtype, {
         return itemstack
     end,
 })
+if has_xcompat then
+    minetest.register_craft({
+        output = "repainter:rotator_"..rtype,
+        recipe = {
+            { xcompat.materials["steel_ingot"] },
+            { wool_name..color_assignment[rtype] },
+            { xcompat.materials["steel_ingot"] }
+        }
+    })
+elseif has_mcl_core then
+    minetest.register_craft({
+        output = "repainter:rotator_"..rtype,
+        recipe = {
+            { "mcl_core:iron_ingot" },
+            { "mcl_wool:"..color_assignment[rtype] },
+            { "mcl_core:iron_ingot" }
+        }
+    })
+else
+    -- default
+    minetest.register_craft({
+        output = "repainter:rotator_"..rtype,
+        recipe = {
+            { "default:steel_ingot" },
+            { "wool:"..color_assignment[rtype] },
+            { "default:steel_ingot" }
+        }
+    })
+end
 end
 
 --


### PR DESCRIPTION
As discussed in the [forum thread](https://forum.luanti.org/viewtopic.php?t=31792). Please find some simple recipes that seem balanced to me. In Mineclonia, the screwdriver, which does similar rotation operations, is a very simple recipe which can be accomplished in the early part of a survival game.